### PR TITLE
Linter fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,9 @@ go:
 - 1.8
 - tip
 
-before_script:
-- go get github.com/alecthomas/gometalinter
-- gometalinter --install
-
 script:
 - go install ./...
 - go test -v -race $(go list ./... | grep -v /vendor/)
-- gometalinter ./... --vendor --disable gocyclo --disable gas --disable goconst
+- retool sync
+- retool do gometalinter --install
+- retool do gometalinter ./... --vendor --disable gocyclo --disable gas --disable goconst

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ go:
 - 1.8
 - tip
 
-script:
+before_script:
 - go get github.com/alecthomas/gometalinter
+- gometalinter --install
+
+script:
 - go install ./...
 - go test -v -race $(go list ./... | grep -v /vendor/)
 - gometalinter ./... --vendor --disable gocyclo --disable gas --disable goconst

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
-sudo: false
 language: go
-go:
-- 1.8
 go_import_path: github.com/twitchtv/retool
+
+go:
+- 1.7.5
+- 1.8
+- tip
+
 script:
+- go get github.com/alecthomas/gometalinter
 - go install ./...
 - go test -v -race $(go list ./... | grep -v /vendor/)
+- gometalinter ./... --vendor --disable gocyclo --disable gas --disable goconst

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
 - go install ./...
 - go test -v -race $(go list ./... | grep -v /vendor/)
 - go vet $(go list ./... | grep -v /vendor/)
-- go vet -shadow *.go
+- go tool vet -shadow *.go
 
 - retool sync
 - retool do errcheck *.go

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,15 @@ go:
 script:
 - go install ./...
 - go test -v -race $(go list ./... | grep -v /vendor/)
+- go vet $(go list ./... | grep -v /vendor/)
+- go vet -shadow *.go
+
 - retool sync
-- retool do gometalinter --install
-- retool do gometalinter ./... --vendor --disable gocyclo --disable gas --disable goconst
+- retool do errcheck *.go
+- retool do deadcode .
+- retool do varcheck ./...
+- retool do aligncheck ./...
+- retool do varcheck ./...
+- retool do ineffassign .
+
+

--- a/do.go
+++ b/do.go
@@ -10,9 +10,9 @@ import (
 func setPath() (unset func()) {
 	prevpath := os.Getenv("PATH")
 	newPath := path.Join(toolDirPath, "bin") + ":" + prevpath
-	os.Setenv("PATH", newPath)
+	_ = os.Setenv("PATH", newPath)
 	return func() {
-		os.Setenv("PATH", prevpath)
+		_ = os.Setenv("PATH", prevpath)
 	}
 }
 

--- a/input.go
+++ b/input.go
@@ -14,12 +14,10 @@ var (
 	positionalArgs []string
 )
 
-// TODO: Will this bother errcheck?
-func verbosef(format string, a ...interface{}) (n int, err error) {
+func verbosef(format string, a ...interface{}) {
 	if *verboseFlag {
-		return fmt.Fprintf(os.Stderr, format, a...)
+		_, _ = fmt.Fprintf(os.Stderr, format, a...)
 	}
-	return 0, nil
 }
 
 func parseArgs() (command string, t *tool) {

--- a/main.go
+++ b/main.go
@@ -40,33 +40,39 @@ func main() {
 
 	if !specExists() {
 		if cmd == "add" {
-			writeBlankSpec()
+			err := writeBlankSpec()
+			if err != nil {
+				fatal("failed to write blank spec", err)
+			}
 		} else {
 			fatal("tools.json does not yet exist. You need to add a tool first with 'retool add'", nil)
 		}
 	}
 
-	spec, err := read()
+	s, err := read()
 	if err != nil {
 		fatal("failed to load tools.json", err)
 	}
 
 	switch cmd {
 	case "add":
-		spec.add(tool)
+		s.add(tool)
 	case "upgrade":
-		spec.upgrade(tool)
+		s.upgrade(tool)
 	case "remove":
-		spec.remove(tool)
+		s.remove(tool)
 	case "build":
-		spec.build()
+		s.build()
 	case "sync":
-		spec.sync()
+		s.sync()
 	case "do":
-		spec.sync()
+		s.sync()
 		do()
 	case "clean":
-		os.RemoveAll(cacheDir)
+		err = os.RemoveAll(cacheDir)
+		if err != nil {
+			fatal("Failure during clean", err)
+		}
 	default:
 		fatal(fmt.Sprintf("unknown cmd %q", cmd), nil)
 	}

--- a/retool_test.go
+++ b/retool_test.go
@@ -34,14 +34,18 @@ func TestRetool(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(retool)
+	defer func() {
+		_ = os.Remove(retool)
+	}()
 
 	t.Run("cache pollution", func(t *testing.T) {
 		dir, err := ioutil.TempDir("", "")
 		if err != nil {
 			t.Fatalf("unable to make temp dir: %s", err)
 		}
-		defer os.RemoveAll(dir)
+		defer func() {
+			_ = os.RemoveAll(dir)
+		}()
 
 		// This should fail because this version of mockery has an import line that points to uber's
 		// internal repo, which can't be reached:
@@ -72,7 +76,9 @@ func TestRetool(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unable to make temp dir: %s", err)
 		}
-		defer os.RemoveAll(dir)
+		defer func() {
+			_ = os.RemoveAll(dir)
+		}()
 
 		// Should work even in a directory without tools.json
 		cmd := exec.Command(retool, "version")
@@ -91,7 +97,9 @@ func TestRetool(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unable to make temp dir: %s", err)
 		}
-		defer os.RemoveAll(dir)
+		defer func() {
+			_ = os.RemoveAll(dir)
+		}()
 
 		cmd := exec.Command(retool, "-base-dir", dir, "add",
 			"github.com/twitchtv/retool", "origin/master",
@@ -103,9 +111,9 @@ func TestRetool(t *testing.T) {
 		}
 
 		// Suppose we only have _tools/src available. Does `retool build` work?
-		os.RemoveAll(filepath.Join(dir, "_tools", "bin"))
-		os.RemoveAll(filepath.Join(dir, "_tools", "pkg"))
-		os.RemoveAll(filepath.Join(dir, "_tools", "manifest.json"))
+		_ = os.RemoveAll(filepath.Join(dir, "_tools", "bin"))
+		_ = os.RemoveAll(filepath.Join(dir, "_tools", "pkg"))
+		_ = os.RemoveAll(filepath.Join(dir, "_tools", "manifest.json"))
 
 		cmd = exec.Command(retool, "-base-dir", dir, "build")
 		cmd.Dir = dir

--- a/spec.go
+++ b/spec.go
@@ -21,7 +21,9 @@ func (s spec) write() error {
 	if err != nil {
 		return fmt.Errorf("unable to open %s: %s", specfile, err)
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	bytes, err := json.MarshalIndent(s, "", "  ")
 	if err != nil {
@@ -60,7 +62,9 @@ func read() (spec, error) {
 	if err != nil {
 		return spec{}, fmt.Errorf("unable to open spec file at %s: %s", specfile, err)
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	s := new(spec)
 	err = json.NewDecoder(file).Decode(s)

--- a/sync.go
+++ b/sync.go
@@ -18,11 +18,14 @@ func (s spec) sync() {
 		}
 
 		// Recreate the tools directory
-		ensureTooldir()
+		err = ensureTooldir()
+		if err != nil {
+			fatal("failed to ensure tool dir", err)
+		}
 
 		// Download everything to cache
 		for _, t := range s.Tools {
-			err := download(t)
+			err = download(t)
 			if err != nil {
 				fatalExec("failed to sync "+t.Repository, err)
 			}

--- a/tool.go
+++ b/tool.go
@@ -70,11 +70,14 @@ func setVersion(t *tool) error {
 	if t.Fork != "" {
 		cmd := exec.Command("git", "remote", "rm", "fork")
 		cmd.Dir = t.path()
-		cmd.Output()
+		_, err := cmd.Output()
+		if err != nil {
+			return err
+		}
 
 		cmd = exec.Command("git", "remote", "add", "-f", "fork", t.Fork)
 		cmd.Dir = t.path()
-		_, err := cmd.Output()
+		_, err = cmd.Output()
 		if err != nil {
 			return err
 		}
@@ -93,7 +96,9 @@ func setVersion(t *tool) error {
 		log(fmt.Sprintf("parsing revision %q", t.ref))
 		cmd = exec.Command("git", "rev-parse", t.ref)
 		cmd.Dir = t.path()
-		out, err := cmd.Output()
+
+		var out []byte
+		out, err = cmd.Output()
 		if err != nil {
 			return err
 		}

--- a/tooldir.go
+++ b/tooldir.go
@@ -53,7 +53,8 @@ func ensureTooldir() error {
 
 	baseDirPath = *baseDir
 	if baseDirPath == "" {
-		repoRootPath, err := getRepoRoot()
+		var repoRootPath string
+		repoRootPath, err = getRepoRoot()
 		if err != nil {
 			return errors.Wrap(err, "failed to check for enclosing git repository")
 		}
@@ -90,7 +91,7 @@ func ensureTooldir() error {
 
 	err = ioutil.WriteFile(path.Join(toolDirPath, ".gitignore"), gitignore, 0664)
 	if err != nil {
-		errors.Wrap(err, "unable to update .gitignore")
+		return errors.Wrap(err, "unable to update .gitignore")
 	}
 
 	return nil

--- a/tools.json
+++ b/tools.json
@@ -1,8 +1,32 @@
 {
   "Tools": [
     {
-      "Repository": "github.com/alecthomas/gometalinter",
-      "Commit": "e8ad4316afe4ae968b63fffc9d9dbd423d28f49f"
+      "Repository": "github.com/golang/lint/golint",
+      "Commit": "cb00e5669539f047b2f4c53a421a01b0c8e172c6"
+    },
+    {
+      "Repository": "github.com/tsenart/deadcode",
+      "Commit": "210d2dc333e90c7e3eedf4f2242507a8e83ed4ab"
+    },
+    {
+      "Repository": "github.com/opennota/check/cmd/varcheck",
+      "Commit": "5b00aacd5639507d2b039245a278ec9f5505509f"
+    },
+    {
+      "Repository": "github.com/opennota/check/cmd/aligncheck",
+      "Commit": "5b00aacd5639507d2b039245a278ec9f5505509f"
+    },
+    {
+      "Repository": "github.com/opennota/check/cmd/structcheck",
+      "Commit": "5b00aacd5639507d2b039245a278ec9f5505509f"
+    },
+    {
+      "Repository": "github.com/kisielk/errcheck",
+      "Commit": "db0ca22445717d1b2c51ac1034440e0a2a2de645"
+    },
+    {
+      "Repository": "github.com/gordonklaus/ineffassign",
+      "Commit": "99762ed65232b1477364c8c53778f8b6503e868c"
     }
   ]
 }

--- a/tools.json
+++ b/tools.json
@@ -1,0 +1,8 @@
+{
+  "Tools": [
+    {
+      "Repository": "github.com/alecthomas/gometalinter",
+      "Commit": "e8ad4316afe4ae968b63fffc9d9dbd423d28f49f"
+    }
+  ]
+}


### PR DESCRIPTION
Your choice on this, required if you want linting to run in CI

clean with `gometalinter ./... --vendor --disable gocyclo --disable gas
--disable goconst` the errors in `gas` are mainly because you are
shelling out to a variable (security issue, but required for retool to
work) and goconst doesn't like the reuse of constants like `"clean"` and
`"add"`