### PR TITLE
Keep legal files when vendoring tools

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -128,19 +128,35 @@ func keepFile(filename string) bool {
 }
 
 var commonLegalFilePrefixes = []string{
-	"license",
-	"licence",
-	"legal",
+	"licence", // UK spelling
+	"license", // US spelling
 	"copying",
-	"copyright",
 	"unlicense",
+	"copyright",
+	"copyleft",
+	"authors",
+	"contributors",
 	"readme", // often has a license inline
+}
+
+var commonLegalFileSubstrings = []string{
+	"legal",
+	"notice",
+	"disclaimer",
+	"patent",
+	"third-party",
+	"thirdparty",
 }
 
 func isLegalFile(filename string) bool {
 	base := strings.ToLower(filepath.Base(filename))
 	for _, p := range commonLegalFilePrefixes {
 		if strings.HasPrefix(base, p) {
+			return true
+		}
+	}
+	for _, s := range commonLegalFileSubstrings {
+		if strings.Contains(base, s) {
 			return true
 		}
 	}

--- a/clean.go
+++ b/clean.go
@@ -77,15 +77,12 @@ func clean(pkgs []string) {
 			return err
 		}
 
-		// Delete files in packages that aren't marked as "keep",
-		// and any non-go or test files.
+		// Delete files in packages that aren't in packages we need to build the
+		// tools, and any non-go, non-legal files in packages we *do* need.
 		if info.Mode().IsRegular() {
 			pkg = filepath.Dir(pkg)
 			_, keptPkg := keep[pkg]
-			isGo := strings.HasSuffix(path, ".go")
-			isAssembly := strings.HasSuffix(path, ".s")
-			isTest := strings.HasSuffix(path, "_test.go")
-			if !keptPkg || !(isGo || isAssembly) || isTest {
+			if !(keptPkg && keepFile(path)) {
 				toDelete = append(toDelete, path)
 			}
 			return nil
@@ -112,4 +109,40 @@ func clean(pkgs []string) {
 			fatal("unable to remove file or directory", err)
 		}
 	}
+}
+
+func keepFile(filename string) bool {
+	if strings.HasSuffix(filename, "_test.go") {
+		return false
+	}
+	if strings.HasSuffix(filename, ".go") {
+		return true
+	}
+	if strings.HasSuffix(filename, ".s") {
+		return true
+	}
+	if isLegalFile(filename) {
+		return true
+	}
+	return false
+}
+
+var commonLegalFilePrefixes = []string{
+	"license",
+	"licence",
+	"legal",
+	"copying",
+	"copyright",
+	"unlicense",
+	"readme", // often has a license inline
+}
+
+func isLegalFile(filename string) bool {
+	base := strings.ToLower(filepath.Base(filename))
+	for _, p := range commonLegalFilePrefixes {
+		if strings.HasPrefix(base, p) {
+			return true
+		}
+	}
+	return false
 }

--- a/clean_test.go
+++ b/clean_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestIsLegalFile(t *testing.T) {
+	testcase := func(filename string, want bool) {
+		t.Run(filename, func(t *testing.T) {
+			have := isLegalFile(filename)
+			if have != want {
+				t.Fail()
+			}
+		})
+	}
+
+	testcase("license.md", true)
+	testcase("license.txt", true)
+	testcase("LICENSE", true)
+	testcase("LICENCE", true)
+	testcase("LICENSE.md", true)
+	testcase(filepath.Join("pkg", "LICENSE.md"), true)
+	testcase("LEGAL", true)
+	testcase("README", true)
+	testcase("COPYING", true)
+	testcase("COPYRIGHT", true)
+	testcase("UNLICENSE", true)
+
+	testcase("picture.jpeg", false)
+}
+
+func TestKeep(t *testing.T) {
+	testcase := func(filename string, want bool) {
+		t.Run(filename, func(t *testing.T) {
+			have := keepFile(filename)
+			if have != want {
+				t.Fail()
+			}
+		})
+	}
+
+	testcase("program.go", true)
+	testcase("program_test.go", false)
+	testcase(filepath.Join("pkg", "program.go"), true)
+	testcase(filepath.Join("pkg", "program_test.go"), false)
+
+	testcase("assembly.s", true)
+	testcase("notassembly.as", false)
+	testcase("picture.gif", false)
+	testcase("LICENSE.md", true)
+}

--- a/clean_test.go
+++ b/clean_test.go
@@ -26,7 +26,9 @@ func TestIsLegalFile(t *testing.T) {
 	testcase("COPYING", true)
 	testcase("COPYRIGHT", true)
 	testcase("UNLICENSE", true)
+	testcase("PATENTS", true)
 
+	testcase(filepath.Join("pat", "ents"), false)
 	testcase("picture.jpeg", false)
 }
 

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 )
 
-const version = "v1.0.3"
+const version = "v1.1.0"
 
 var cacheDir = ""
 

--- a/retool_test.go
+++ b/retool_test.go
@@ -119,13 +119,19 @@ func TestRetool(t *testing.T) {
 		cmd.Dir = dir
 		_, err = cmd.Output()
 		if err != nil {
-			t.Fatalf("expected no errors when using retool build, have this:\n%s", string(err.(*exec.ExitError).Stderr))
+			t.Errorf("expected no errors when using retool build, have this:\n%s", string(err.(*exec.ExitError).Stderr))
 		}
 
 		// Now the binary should be installed
 		_, err = os.Stat(filepath.Join(dir, "_tools", "bin", "retool"))
 		if err != nil {
-			t.Fatalf("unable to stat _tools/bin/retool after calling retool build: %s", err)
+			t.Errorf("unable to stat _tools/bin/retool after calling retool build: %s", err)
+		}
+
+		// Legal files should be kept around
+		_, err = os.Stat(filepath.Join(dir, "_tools", "src", "github.com", "twitchtv", "retool", "LICENSE"))
+		if err != nil {
+			t.Error("missing license file")
 		}
 	})
 


### PR DESCRIPTION
This is overdue, for sure!

We shouldn't be trimming out legal files. This also gives us a place to handle future exceptions, like we might want to do for #7.