### PR TITLE
Windows CI on Appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,4 +25,4 @@ build: false
 deploy: false
 
 test_script:
-  - go test -v -race $(go list ./... | grep -v /vendor/)
+  - go test -v -race .

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,28 @@
+version: "{build}"
+
+clone_folder: c:\gopath\src\github.com\twitchtv/retool
+
+environment:
+  GOPATH: c:\gopath
+  matrix:
+    - environment:
+      GOVERSION: 1.7.5
+    - environment:
+      GOVERSION: 1.8
+
+install:
+  # Install the specific Go version.
+  - rmdir c:\go /s /q
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-amd64.msi
+  - msiexec /i go%GOVERSION%.windows-amd64.msi /q
+  - set Path=c:\go\bin;c:\gopath\bin;%Path%
+  - go version
+  - go env
+  - go install ./...
+  - retool build
+
+build: false
+deploy: false
+
+test_script:
+  - go test -v -race $(go list ./... | grep -v /vendor/)


### PR DESCRIPTION
Adds .appveyor.yml. Builds can be seen on https://ci.appveyor.com/project/spenczar/retool. Yay!

Unfortunately, the build doesn't work yet. I'll fix bugs in separate revisions.