### PR TITLE
Stop using a cache

### DIFF
--- a/input.go
+++ b/input.go
@@ -114,7 +114,7 @@ func printUsageAndExit(command string, exitCode int) {
 	os.Exit(exitCode)
 }
 
-const usage = `usage: retool (add | remove | upgrade | sync | do | clean | build | help)
+const usage = `usage: retool (add | remove | upgrade | sync | do | build | help)
 
 use retool with a subcommand:
 
@@ -124,7 +124,6 @@ upgrade will upgrade a tool
 sync will synchronize your _tools with tools.json, downloading if necessary
 build will compile all the tools in _tools
 do will run stuff using your installed tools
-clean will delete the repo cache stored at ~/.retool
 
 help [command] will describe a command in more detail
 version will print the installed version of retool
@@ -187,11 +186,7 @@ That works too.
 
 const cleanUsage = `usage: retool clean
 
-retool clean will delete the repo cache stored at ~/.retool
-
-This is just
-  rm -rf ~/.retool
-That works too.
+retool clean has no effect, but still exists for compatibility.
 `
 
 const buildUsage = `usage: retool build

--- a/main.go
+++ b/main.go
@@ -4,27 +4,9 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"os/user"
-	"path/filepath"
 )
 
 const version = "v1.0.3"
-
-var cacheDir = ""
-
-func init() {
-	u, err := user.Current()
-	if err == nil && u.HomeDir != "" {
-		cacheDir = filepath.Join(u.HomeDir, ".retool")
-	} else {
-		cwd, err := os.Getwd()
-		if err == nil {
-			cacheDir = filepath.Join(cwd, ".retool")
-		} else {
-			cacheDir = ".retool"
-		}
-	}
-}
 
 func main() {
 	flag.Parse()
@@ -69,10 +51,7 @@ func main() {
 		s.sync()
 		do()
 	case "clean":
-		err = os.RemoveAll(cacheDir)
-		if err != nil {
-			fatal("Failure during clean", err)
-		}
+		log("the clean subcommand is deprecated and has no effect")
 	default:
 		fatal(fmt.Sprintf("unknown cmd %q", cmd), nil)
 	}

--- a/retool_test.go
+++ b/retool_test.go
@@ -148,4 +148,17 @@ func TestRetool(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("clean", func(t *testing.T) {
+		// Clean should be a noop, but kept around for compatibility
+		cmd := exec.Command(retool, "clean")
+		_, err := cmd.Output()
+		if err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				t.Fatalf("expected no errors when using retool clean, have this:\n%s", string(exitErr.Stderr))
+			} else {
+				t.Fatalf("unexpected err when running %q: %q", strings.Join(cmd.Args, " "), err)
+			}
+		}
+	})
 }

--- a/sync.go
+++ b/sync.go
@@ -1,9 +1,6 @@
 package main
 
-import (
-	"os/exec"
-	"path/filepath"
-)
+import "os/exec"
 
 func (s spec) sync() {
 	m := getManifest()
@@ -23,19 +20,12 @@ func (s spec) sync() {
 			fatal("failed to ensure tool dir", err)
 		}
 
-		// Download everything to cache
+		// Download everything to tool directory
 		for _, t := range s.Tools {
 			err = download(t)
 			if err != nil {
 				fatalExec("failed to sync "+t.Repository, err)
 			}
-		}
-
-		// Copy the cache into the tools directory
-		cmd = exec.Command("cp", "-R", filepath.Join(cacheDir, "src"), filepath.Join(toolDirPath, "src"))
-		_, err = cmd.Output()
-		if err != nil {
-			fatalExec("failed to copy data from cache ", err)
 		}
 
 		// Install the packages

--- a/tool.go
+++ b/tool.go
@@ -48,12 +48,6 @@ func setEnvVar(cmd *exec.Cmd, key, val string) {
 }
 
 func get(t *tool) error {
-	// If the repo is already downloaded, then we can exit early
-	if _, err := os.Stat(filepath.Join(toolDirPath, "src", t.Repository)); err == nil {
-		log(t.Repository + " already exists, skipping 'get' step")
-		return nil
-	}
-
 	log("downloading " + t.Repository)
 	cmd := exec.Command("go", "get", "-d", t.Repository)
 	setEnvVar(cmd, "GOPATH", toolDirPath)

--- a/tool.go
+++ b/tool.go
@@ -18,7 +18,7 @@ type tool struct {
 }
 
 func (t *tool) path() string {
-	return filepath.Join(cacheDir, "src", t.Repository)
+	return filepath.Join(toolDirPath, "src", t.Repository)
 }
 
 func (t *tool) executable() string {
@@ -48,15 +48,15 @@ func setEnvVar(cmd *exec.Cmd, key, val string) {
 }
 
 func get(t *tool) error {
-	// If the repo is already downloaded to the cache, then we can exit early
-	if _, err := os.Stat(filepath.Join(cacheDir, "src", t.Repository)); err == nil {
+	// If the repo is already downloaded, then we can exit early
+	if _, err := os.Stat(filepath.Join(toolDirPath, "src", t.Repository)); err == nil {
 		log(t.Repository + " already exists, skipping 'get' step")
 		return nil
 	}
 
 	log("downloading " + t.Repository)
 	cmd := exec.Command("go", "get", "-d", t.Repository)
-	setEnvVar(cmd, "GOPATH", cacheDir)
+	setEnvVar(cmd, "GOPATH", toolDirPath)
 	_, err := cmd.Output()
 	if err != nil {
 		return errors.Wrap(err, "failed to 'go get' tool")
@@ -114,7 +114,7 @@ func setVersion(t *tool) error {
 
 	// Re-run 'go get' in case the new version has a different set of dependencies.
 	cmd = exec.Command("go", "get", "-d", t.Repository)
-	setEnvVar(cmd, "GOPATH", cacheDir)
+	setEnvVar(cmd, "GOPATH", toolDirPath)
 	_, err = cmd.Output()
 	if err != nil {
 		return errors.Wrap(err, "failed to 'go get' tool")


### PR DESCRIPTION
The cache was well-intentioned, but caused lots of tricky bugs. It could get polluted with bad versions of dependencies, for example, and its existence was always hard to justify. It doesn't make things much faster, really, except when adding lots of dependencies to a project at once, and there are better ways towards speed for that use case. Specifically, we can stop syncing on every `retool add` and `retool remove` command and only sync when we need to (ie, right before `retool do`, and even then only if binaries aren't installed).

This revision keeps the `retool clean` command around for compatibility, but it doesn't do anything anymore.