### PR TITLE
Fix gometalinter

### DIFF
--- a/do.go
+++ b/do.go
@@ -18,7 +18,12 @@ func setPath() (unset func()) {
 
 func setGoEnv() (unset func()) {
 	prevGoPath, goPathWasSet := os.LookupEnv("GOPATH")
-	newGoPath := toolDirPath
+	var newGoPath string
+	if goPathWasSet {
+		newGoPath = prevGoPath + string(os.PathListSeparator) + toolDirPath
+	} else {
+		newGoPath = toolDirPath
+	}
 	_ = os.Setenv("GOPATH", newGoPath)
 
 	prevGoBin, goBinWasSet := os.LookupEnv("GOBIN")

--- a/do.go
+++ b/do.go
@@ -13,9 +13,15 @@ func setPath() error {
 	return os.Setenv("PATH", newPath)
 }
 
-func setGoBin() error {
+func setGoEnv() error {
 	newGoBin := filepath.Join(toolDirPath, "bin")
-	return os.Setenv("GOBIN", newGoBin)
+	if err := os.Setenv("GOBIN", newGoBin); err != nil {
+		return err
+	}
+
+	prevGoPath := os.Getenv("GOPATH")
+	newGoPath := toolDirPath + string(os.PathListSeparator) + prevGoPath
+	return os.Setenv("GOPATH", newGoPath)
 }
 
 func do() {
@@ -27,9 +33,12 @@ func do() {
 	if err := setPath(); err != nil {
 		fatal("unable to set PATH", err)
 	}
-	if err := setGoBin(); err != nil {
-		fatal("unable to set GOBIN", err)
+	if err := setGoEnv(); err != nil {
+		fatal("unable to set up go environment variables", err)
 	}
+
+	unsetGoEnv := setGoEnv()
+	defer unsetGoEnv()
 
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stdin = os.Stdin

--- a/do.go
+++ b/do.go
@@ -16,13 +16,40 @@ func setPath() (unset func()) {
 	}
 }
 
+func setGoEnv() (unset func()) {
+	prevGoPath, goPathWasSet := os.LookupEnv("GOPATH")
+	newGoPath := toolDirPath
+	_ = os.Setenv("GOPATH", newGoPath)
+
+	prevGoBin, goBinWasSet := os.LookupEnv("GOBIN")
+	newGoBin := filepath.Join(toolDirPath, "bin")
+	_ = os.Setenv("GOBIN", newGoBin)
+
+	return func() {
+		if goPathWasSet {
+			_ = os.Setenv("GOPATH", prevGoPath)
+		} else {
+			_ = os.Unsetenv("GOPATH")
+		}
+		if goBinWasSet {
+			_ = os.Setenv("GOBIN", prevGoBin)
+		} else {
+			_ = os.Unsetenv("GOBIN")
+		}
+	}
+}
+
 func do() {
 	args := positionalArgs
 	if len(args) == 0 {
 		fatal("no command passed to retool do", nil)
 	}
 
-	defer setPath()()
+	unsetPath := setPath()
+	defer unsetPath()
+
+	unsetGoEnv := setGoEnv()
+	defer unsetGoEnv()
 
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stdin = os.Stdin

--- a/do.go
+++ b/do.go
@@ -37,9 +37,6 @@ func do() {
 		fatal("unable to set up go environment variables", err)
 	}
 
-	unsetGoEnv := setGoEnv()
-	defer unsetGoEnv()
-
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr

--- a/retool_test.go
+++ b/retool_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -120,6 +121,47 @@ func TestRetool(t *testing.T) {
 			t.Errorf("have=%q, want=%q", string(out), want)
 		}
 	})
+	t.Run("gometalinter exemption", func(t *testing.T) {
+		dir, err := ioutil.TempDir("", "")
+		if err != nil {
+			t.Fatalf("unable to make temp dir: %s", err)
+		}
+		defer func() {
+			_ = os.RemoveAll(dir)
+		}()
+
+		runRetoolCmd(t, dir, retool, "add", "github.com/alecthomas/gometalinter", "origin/master")
+		runRetoolCmd(t, dir, retool, "do", "gometalinter", "--install")
+
+		// Create a dummy go file so gometalinter runs. If we don't do this,
+		// gometalinter will exit without doing any work, and we'll get a false
+		// positive.
+		//
+		// The file will be removed with the deferred os.RemoveAll(dir) call, no
+		// need to remove it here.
+		f, err := os.Create(filepath.Join(dir, "main.go"))
+		if err != nil {
+			t.Fatalf("unable to create file for gometalinter to run against: %s", err)
+		}
+		defer func() {
+			if err := f.Close(); err != nil {
+				t.Errorf("unable to close gometalinter test file: %s", err)
+			}
+		}()
+		_, err = io.WriteString(f, `package main
+
+func main() {}`)
+		if err != nil {
+			t.Fatalf("unable to write gometalinter test file: %s", err)
+		}
+
+		// If gometalinter can't find its tools, it will exit with code 2.
+		runRetoolCmd(t, dir, retool, "do", "gometalinter", ".")
+
+		// Make sure gometalinter installs to the tool directory, not to the global
+		// GOPATH.
+		assertBinInstalled(t, dir, "structcheck")
+	})
 }
 
 func runRetoolCmd(t *testing.T, dir, retool string, args ...string) (output string) {
@@ -129,7 +171,7 @@ func runRetoolCmd(t *testing.T, dir, retool string, args ...string) (output stri
 	out, err := cmd.Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			t.Fatalf("command %q failed: %s", "retool "+strings.Join(cmd.Args[1:], " "), string(exitErr.Stderr))
+			t.Fatalf("command %q failed, stderr:\n%s\n\nstdout:%s", "retool "+strings.Join(cmd.Args[1:], " "), string(exitErr.Stderr), string(out))
 		} else {
 			t.Fatalf("unexpected err when running %q: %q", strings.Join(cmd.Args, " "), err)
 		}

--- a/retool_test.go
+++ b/retool_test.go
@@ -144,8 +144,8 @@ func TestRetool(t *testing.T) {
 			t.Fatalf("unable to create file for gometalinter to run against: %s", err)
 		}
 		defer func() {
-			if err := f.Close(); err != nil {
-				t.Errorf("unable to close gometalinter test file: %s", err)
+			if closeErr := f.Close(); closeErr != nil {
+				t.Errorf("unable to close gometalinter test file: %s", closeErr)
 			}
 		}()
 		_, err = io.WriteString(f, `package main


### PR DESCRIPTION
Two changes are required:

First, we need to not delete the `github.com/alecthomas/gometalinter/_linters` directory, since it contains the vendored source for gometalinter's linters.

Second, we need to set GOBIN and GOPATH for our `retool do` subcommand. `gometalinter` uses these environment variables to find its vendored linters.

Depends on #14.
Fixes #7.

