### PR TITLE
Fixed retool sync on windows

### DIFF
--- a/retool_test.go
+++ b/retool_test.go
@@ -55,6 +55,21 @@ func TestRetool(t *testing.T) {
 		}
 	})
 
+	t.Run("sync", func(t *testing.T) {
+		dir, cleanup := setupTempDir(t)
+		defer cleanup()
+
+		runRetoolCmd(t, dir, retool, "add", "github.com/twitchtv/retool", "origin/master")
+
+		// Delete existing tools directory to try and trigger out of date
+		_ = os.RemoveAll(filepath.Join(dir, "_tools"))
+
+		// Should be able to sync
+		runRetoolCmd(t, dir, retool, "sync")
+
+		assertBinInstalled(t, dir, "retool")
+	})
+
 	t.Run("build", func(t *testing.T) {
 		dir, cleanup := setupTempDir(t)
 		defer cleanup()
@@ -121,6 +136,7 @@ func TestRetool(t *testing.T) {
 			t.Errorf("have=%q, want=%q", string(out), want)
 		}
 	})
+
 	t.Run("gometalinter exemption", func(t *testing.T) {
 		dir, err := ioutil.TempDir("", "")
 		if err != nil {

--- a/sync.go
+++ b/sync.go
@@ -1,15 +1,12 @@
 package main
 
-import "os/exec"
+import "os"
 
 func (s spec) sync() {
 	m := getManifest()
 	if m.outOfDate(s.Tools) {
-		log("syncing")
-
 		// Delete existing tools directory
-		cmd := exec.Command("rm", "-r", "-f", toolDirPath)
-		_, err := cmd.Output()
+		err := os.RemoveAll(toolDirPath)
 		if err != nil {
 			fatalExec("failed to remove _tools ", err)
 		}


### PR DESCRIPTION
I changed a exec.Command call that called rm to os.RemoveAll.
exec.Command breaks on windows because rm being called. Lastly I added a
test to help prevent regression.