### PR TITLE
Fix `setVersion` for forked repos

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -63,14 +63,11 @@ func setVersion(t *tool) error {
 	if t.Fork != "" {
 		cmd := exec.Command("git", "remote", "rm", "fork")
 		cmd.Dir = t.path()
-		_, err := cmd.Output()
-		if err != nil {
-			return err
-		}
+		_, _ = cmd.Output()
 
 		cmd = exec.Command("git", "remote", "add", "-f", "fork", t.Fork)
 		cmd.Dir = t.path()
-		_, err = cmd.Output()
+		_, err := cmd.Output()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Since 6bccfa131c0378a3ce1aa167e9df4979dcff6511 having forks in your manifest would break `setVersion`. The error returned by `git remote rm fork` needs to be ignored, as it is possible (and likely now that the cache is gone) that the remote doesn't exist.