### PR TITLE
Build programs into _tools/bin even if GOBIN is set during `retool build`

### DIFF
--- a/build.go
+++ b/build.go
@@ -3,6 +3,11 @@ package main
 // builds all tools in the spec file using whatever is installed in the tool directory (_tools,
 // typically). Shouldn't do any network if _tools is set up correctly.
 func (s spec) build() {
+	err := setGoEnv()
+	if err != nil {
+		fatal("unable to set GOPATH and GOBIN env variables", err)
+	}
+
 	m := getManifest()
 	for _, t := range s.Tools {
 		err := install(t)

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Masterminds/semver"
 )
 
-var version = semver.MustParse("v1.3.2")
+var version = semver.MustParse("v1.3.3")
 
 func main() {
 	flag.Parse()

--- a/retool_test.go
+++ b/retool_test.go
@@ -99,8 +99,8 @@ func TestRetool(t *testing.T) {
 		})
 
 		t.Run("build_with_gobin_set", func(t *testing.T) {
-			// Set GOBIN to a directory not controlled by retool. It should still
-			// put built binaries in _tools/bin.
+			// Even if GOBIN is set to a directory not controlled by retool, running
+			// 'retool build' should still put built binaries in _tools/bin.
 			t.Parallel()
 			dir, cleanup := setupTempDir(t)
 			defer cleanup()


### PR DESCRIPTION
Fixes #28 by setting GOBIN to retool's _tools/bin path.