### PR TITLE
Handle empty GOPATH

### DIFF
--- a/do.go
+++ b/do.go
@@ -29,6 +29,9 @@ func setGoEnv() error {
 	}
 
 	prevGoPath := os.Getenv("GOPATH")
+	if prevGoPath == "" {
+		prevGoPath = filepath.Join(os.Getenv("HOME"), "go")
+	}
 	newGoPath := prevGoPath + string(os.PathListSeparator) + toolDirPath
 	return os.Setenv("GOPATH", newGoPath)
 }

--- a/tool.go
+++ b/tool.go
@@ -41,7 +41,7 @@ func setEnvVar(cmd *exec.Cmd, key, val string) {
 		}
 	}
 	if !envSet {
-		env = append(cmd.Env, key+"="+val)
+		env = append(env, key+"="+val)
 	}
 
 	cmd.Env = env


### PR DESCRIPTION
In Go 1.9 there is now a default GOPATH, which retool does not handle gracefully. This fixes it for `sync` and `go`, I have not tested other commands.