### PR TITLE
Add gopkg.in alias for gometalinter to preservedDirectories

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -187,6 +187,7 @@ var preservedDirectories = []string{
 	// gometalinter vendors its own linters and relies on this directory's
 	// existence. See issue #7.
 	filepath.Join("github.com", "alecthomas", "gometalinter", "_linters"),
+	filepath.Join("gopkg.in", "alecthomas", "gometalinter.v2", "_linters"),
 
 	// sqlboiler requires template files to exist at runtime. See pull request #25.
 	filepath.Join("github.com", "vattle", "sqlboiler", "templates"),


### PR DESCRIPTION
Lets you keep vendored linters when importing gometalinter as `gopkg.in/alecthomas/gometalinter.v2`.