### PR TITLE
fix error with golint pathing

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -1,8 +1,8 @@
 {
   "Tools": [
     {
-      "Repository": "github.com/golang/lint/golint",
-      "Commit": "cb00e5669539f047b2f4c53a421a01b0c8e172c6"
+      "Repository": "golang.org/x/lint/golint",
+      "Commit": "959b441ac422379a43da2230f62be024250818b0"
     },
     {
       "Repository": "github.com/tsenart/deadcode",
@@ -35,7 +35,11 @@
     {
       "Repository": "github.com/mitchellh/gox",
       "Commit": "c9740af9c6574448fd48eb30a71f964014c7a837"
+    },
+    {
+      "Repository": "github.com/jteeuwen/go-bindata/go-bindata",
+      "Commit": "6025e8de665b31fa74ab1a66f2cddd8c0abf887e"
     }
   ],
-  "RetoolVersion": "1.3.5"
+  "RetoolVersion": "1.3.7"
 }


### PR DESCRIPTION
**Problem:** . I've been playing with this tool for vendoring and I ran into this issue: 

```retool: downloading github.com/golang/lint/golint
retool: fatal err: execution error on "go get -d github.com/golang/lint/golint": package github.com/golang/lint/golint: code in directory /Users/zuhayrelahi/go-workspace/src/github.com/zelahi/retool/_tools/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"
: failed to 'go get' tool: exit status 1```

It looks like it's related to this issue here: ```https://github.com/golang/lint/issues/415```

After fixing this, the project built and worked without any issues, so wondering if others ran into this error, and hoping this fixes it